### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-entra-overlays-serviceprincipal
+  name: terraform-az-entra-overlays-serviceprincipal
   description: Terraform overlay for Azure Entra ID (AAD) service principals
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-entra-overlays-serviceprincipal
+    github.com/project-slug: POps-Rox/terraform-az-entra-overlays-serviceprincipal
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -13,7 +13,7 @@ metadata:
     - entra-id
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-entra-overlays-serviceprincipal
+    - url: https://github.com/POps-Rox/terraform-az-entra-overlays-serviceprincipal
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/basic_service_principal_with_password/main.tf
+++ b/examples/basic_service_principal_with_password/main.tf
@@ -1,7 +1,7 @@
 
 module "mod_service_principal" {
   source = "../../"
-  #source  = "github.com/POps-Rox/tf-az-entra-overlays-serviceprincipal"
+  #source  = "github.com/POps-Rox/terraform-az-entra-overlays-serviceprincipal"
   #version = "x.x.x"
 
   service_principal_name                       = "dev-app-sp"


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.